### PR TITLE
Removed mount checks from wrapper.py and added full paths to JSON

### DIFF
--- a/rnaseq-cgl-pipeline/rnaseq-cgl-pipeline.json
+++ b/rnaseq-cgl-pipeline/rnaseq-cgl-pipeline.json
@@ -2,15 +2,15 @@
     "samples": [
         {
         "class": "File",
-        "path": "./NA12878-NGv3-LAB1360-A.tar"
+        "path": "/mnt/actiontest/rnaseqteststuff/NA12878-NGv3-LAB1360-A.tar"
         }
     ],
 
-    "star": "./starIndex_hg38_no_alt.tar.gz",
+    "star": "/mnt/actiontest/rnaseqteststuff/starIndex_hg38_no_alt.tar.gz",
 
-    "rsem": "./rsem_ref_hg38_no_alt.tar.gz",
+    "rsem": "/mnt/actiontest/rnaseqteststuff/rsem_ref_hg38_no_alt.tar.gz",
 
-    "kallisto": "./kallisto_hg38.idx",
+    "kallisto": "/mnt/actiontest/rnaseqteststuff/kallisto_hg38.idx",
 
     "disable-cutadapt": false,
 

--- a/rnaseq-cgl-pipeline/wrapper.py
+++ b/rnaseq-cgl-pipeline/wrapper.py
@@ -146,6 +146,7 @@ def main():
     sock_mount = [x['Source'] == x['Destination'] for x in mounts if 'docker.sock' in x['Source']]
     require(len(sock_mount) == 1, 'Missing socket mount. Requires the following: '
                                   'docker run -v /var/run/docker.sock:/var/run/docker.sock')
+    '''
     # Ensure formatting of command for 2 mount points
     if len(mounts) == 2:
         require(all(x['Source'] == x['Destination'] for x in mounts),
@@ -157,6 +158,10 @@ def main():
         mirror_mounts = [x['Source'] for x in mounts if x['Source'] == x['Destination']]
         work_mount = [x for x in mirror_mounts if 'docker.sock' not in x]
         require(len(work_mount) == 1, 'Wrong number of mirror mounts provided, see documentation.')
+    '''
+    work_mount = os.getenv('TMPDIR', os.getcwd())
+
+
     # If sample is given as relative path, assume it's in the work directory
     if not all(x.startswith('/') for x in args.samples):
         args.samples = [os.path.join(work_mount[0], x) for x in args.samples if not x.startswith('/')]


### PR DESCRIPTION
Removed mount checks in wrapper.py that flagged extra mounts
inserted by the dockstore tool runner as errors
Set the working directory to the path in TMPDIR; if TMPDIR is not set
the working directory is set to the current working directory