### PR TITLE
Changed string to File for star, kallisto and rsem in CWL

### DIFF
--- a/rnaseq-cgl-pipeline/rnaseq-cgl-pipeline.cwl
+++ b/rnaseq-cgl-pipeline/rnaseq-cgl-pipeline.cwl
@@ -37,19 +37,19 @@ inputs:
       prefix: --samples
 
   star:
-    type: string
+    type: File
     doc: "Absolute path to STAR index tarball."
     inputBinding:
       prefix: --star
 
   rsem:
-    type: string
+    type: File
     doc: "Absolute path to rsem reference tarball."
     inputBinding:
       prefix: --rsem
 
   kallisto:
-    type: string
+    type: File
     doc: "Absolute path to kallisto index (.idx) file."
     inputBinding:
       prefix: --kallisto


### PR DESCRIPTION
Fixed CWL file by changing 'string' to 'File' for rsem, kallisto, and star